### PR TITLE
corrected api_contraints to api_constraints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-require 'api_contraints'
+require 'api_constraints'
 
 MarketPlaceApi::Application.routes.draw do
   # Api definition


### PR DESCRIPTION
In chapter three:
bundle exec rspec spec/models/user_spec.rb
does not work as the required library is spelled wrong